### PR TITLE
Remove deprecated imports

### DIFF
--- a/amaranth_types/types.py
+++ b/amaranth_types/types.py
@@ -57,9 +57,7 @@ SwitchKey: TypeAlias = str | int | Enum
 SrcLoc: TypeAlias = tuple[str, int]
 
 # Deprecated
-LayoutLike: TypeAlias = (
-    Layout | Sequence[tuple[str, "ShapeLike | LayoutLike"]]
-)
+LayoutLike: TypeAlias = Layout | Sequence[tuple[str, "ShapeLike | LayoutLike"]]
 
 
 # Protocols for Amaranth classes

--- a/amaranth_types/types.py
+++ b/amaranth_types/types.py
@@ -21,7 +21,7 @@ from amaranth import *
 from amaranth.lib.wiring import Flow, Member
 from typing import Sequence
 from amaranth.hdl import ShapeCastable, ValueCastable
-from amaranth.hdl.rec import Layout, Direction
+from amaranth.lib.data import Layout
 
 if TYPE_CHECKING:
     from amaranth.hdl._ast import Statement
@@ -58,7 +58,7 @@ SrcLoc: TypeAlias = tuple[str, int]
 
 # Deprecated
 LayoutLike: TypeAlias = (
-    Layout | Sequence[tuple[str, "ShapeLike | LayoutLike"] | tuple[str, "ShapeLike | LayoutLike", Direction]]
+    Layout | Sequence[tuple[str, "ShapeLike | LayoutLike"] | tuple[str, "ShapeLike | LayoutLike"]]
 )
 
 

--- a/amaranth_types/types.py
+++ b/amaranth_types/types.py
@@ -58,7 +58,7 @@ SrcLoc: TypeAlias = tuple[str, int]
 
 # Deprecated
 LayoutLike: TypeAlias = (
-    Layout | Sequence[tuple[str, "ShapeLike | LayoutLike"] | tuple[str, "ShapeLike | LayoutLike"]]
+    Layout | Sequence[tuple[str, "ShapeLike | LayoutLike"]]
 )
 
 


### PR DESCRIPTION
I started getting these errors:
```
venv/lib/python3.11/site-packages/amaranth_types/types.py:24
  /home/jurb/dev/repos/coreblocks/venv/lib/python3.11/site-packages/amaranth_types/types.py:24: DeprecationWarning: instead of `amaranth.hdl.rec.Layout`, use the `amaranth.lib.data` and `amaranth.lib.wiring` libraries as appropriate for the application; `amaranth.hdl.rec` will be removed in Amaranth 0.6
    from amaranth.hdl.rec import Layout, Direction

venv/lib/python3.11/site-packages/amaranth_types/types.py:24
  /home/jurb/dev/repos/coreblocks/venv/lib/python3.11/site-packages/amaranth_types/types.py:24: DeprecationWarning: instead of `amaranth.hdl.rec.Direction`, use the `amaranth.lib.data` and `amaranth.lib.wiring` libraries as appropriate for the application; `amaranth.hdl.rec` will be removed in Amaranth 0.6
    from amaranth.hdl.rec import Layout, Direction

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```
so I removed one import (`Direction`) altogether and changed the other one according to the hint.