### PR TITLE
lib.wiring: use `AbstractSignature` in `Flow` and `Member`

### DIFF
--- a/amaranth-stubs/lib/wiring.pyi
+++ b/amaranth-stubs/lib/wiring.pyi
@@ -56,7 +56,7 @@ Out = Flow.Out
 In = Flow.In
 
 @final
-class Member(Generic[_T_Signature]):
+class Member:
     """Description of a signature member.
 
     This class is a discriminated union: its instances describe either a `port member` or
@@ -75,7 +75,7 @@ class Member(Generic[_T_Signature]):
     Although instances can be created directly, most often they will be created through
     :data:`In` and :data:`Out`, e.g. :pc:`In(unsigned(1))` or :pc:`Out(stream.Signature(RGBPixel))`.
     """
-    def __init__(self, flow: Flow, description: _T_Signature | ShapeLike, *, reset=..., _dimensions=...) -> None:
+    def __init__(self, flow: Flow, description: AbstractSignature | ShapeLike, *, reset=..., _dimensions=...) -> None:
         ...
     
     def flip(self) -> Member:
@@ -178,7 +178,7 @@ class Member(Generic[_T_Signature]):
         ...
     
     @property
-    def signature(self) -> _T_Signature:
+    def signature(self) -> AbstractSignature:
         """Signature of a signature member.
 
         Returns

--- a/amaranth-stubs/lib/wiring.pyi
+++ b/amaranth-stubs/lib/wiring.pyi
@@ -33,7 +33,7 @@ class Flow(enum.Enum):
         """
         ...
     
-    def __call__(self, description: Signature | ShapeLike, *, reset=...) -> Member:
+    def __call__(self, description: AbstractSignature | ShapeLike, *, reset=...) -> Member:
         """Create a :class:`Member` with this data flow and the provided description and
         reset value.
 
@@ -56,7 +56,7 @@ Out = Flow.Out
 In = Flow.In
 
 @final
-class Member:
+class Member(Generic[_T_Signature]):
     """Description of a signature member.
 
     This class is a discriminated union: its instances describe either a `port member` or
@@ -75,7 +75,7 @@ class Member:
     Although instances can be created directly, most often they will be created through
     :data:`In` and :data:`Out`, e.g. :pc:`In(unsigned(1))` or :pc:`Out(stream.Signature(RGBPixel))`.
     """
-    def __init__(self, flow: Flow, description: Signature | ShapeLike, *, reset=..., _dimensions=...) -> None:
+    def __init__(self, flow: Flow, description: _T_Signature | ShapeLike, *, reset=..., _dimensions=...) -> None:
         ...
     
     def flip(self) -> Member:
@@ -178,7 +178,7 @@ class Member:
         ...
     
     @property
-    def signature(self) -> Signature:
+    def signature(self) -> _T_Signature:
         """Signature of a signature member.
 
         Returns


### PR DESCRIPTION
Needed for https://github.com/kuznia-rdzeni/transactron/pull/42

Replaces `Signature` with `AbstractSignature` in `Flow` and `Member`.
Otherwise `FlippedSignature` doesn't type in In/Out ports, but it is valid there. 